### PR TITLE
Include bundled glew headers when GLEW_STATIC

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -163,6 +163,7 @@ if not have_glew:
     glew = SConscript('src/glew/SConscript', variant_dir = 'build/glew')
     Depends(lib, glew)
     env.Append(_LIBFLAGS = [glew]) # Force to end
+    env.Append(CPPPATH = ['#/src/glew'])
 
 
 # Cairo
@@ -170,7 +171,6 @@ if not have_cairo:
     cairo = SConscript('src/cairo/SConscript', variant_dir = 'build/cairo')
     Depends(lib, cairo)
     env.Append(_LIBFLAGS = [cairo]) # Force to end
-    env.Append(CPPPATH = ['#/src/glew'])
 
 
 # DXFlib

--- a/SConstruct
+++ b/SConstruct
@@ -170,6 +170,7 @@ if not have_cairo:
     cairo = SConscript('src/cairo/SConscript', variant_dir = 'build/cairo')
     Depends(lib, cairo)
     env.Append(_LIBFLAGS = [cairo]) # Force to end
+    env.Append(CPPPATH = ['#/src/glew'])
 
 
 # DXFlib


### PR DESCRIPTION
Not sure this is a desired way of doing it, but it works. This time in correct place, hopefully.
```
g++ -o build/camotics/contour/TriangleSurface.o -c -std=c++11 -Wno-deprecated-declarations -ggdb -Wall -Werror -I/usr/include/v8-3.14/ -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -fPIC -DDEBUG -D_REENTRANT -DHAVE_EXPAT -DHAVE_PTHREADS -DHAVE_LIBSQLITE -DHAVE_OPENSSL -DHAVE_V8 -DDEBUG_LEVEL=1 -DHAVE_CBANG -DUSING_CBANG -DGLEW_STATIC -DQT_CORE_LIB -DQT_GUI_LIB -DQT_OPENGL_LIB -DQT_SHARED -I/builddir/build/BUILD/cbang-7f96da9ccdd8986408c35738e81d4c24600e8537/src -I/builddir/build/BUILD/cbang-7f96da9ccdd8986408c35738e81d4c24600e8537/include -I/builddir/build/BUILD/cbang-7f96da9ccdd8986408c35738e81d4c24600e8537/src/boost -I/usr/include/QtOpenGL -I/usr/include/QtGui -I/usr/include/QtCore -Isrc -Ibuild -Isrc src/camotics/contour/TriangleSurface.cpp
src/camotics/view/GL.h:24:38: fatal error: GL/glew.h: No such file or directory
 #include <GL/glew.h> // Must be first
                                      ^
compilation terminated.
scons: *** [build/camotics/contour/TriangleSurface.o] Error 1
scons: building terminated because of errors.
```