### PR TITLE
Added pkgconf to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ by C!, can be installed with the following command line:
 
     sudo apt-get update
     sudo apt-get -y install scons build-essential qt5-default python-six \
-      libqt5websockets5-dev libqt5opengl5-dev libnode-dev libglu1-mesa-dev git
+      libqt5websockets5-dev libqt5opengl5-dev libnode-dev libglu1-mesa-dev \
+      pkgconf git
 
 ## Building C! (cbang)
 Clone the C! git repository, build the software using scons and set the


### PR DESCRIPTION
On a fresh Debian Buster pkg-config is not installed by default and the CAMotics scons build fails with:
```
Checking for C++ header file cbang/Exception.h... yes
Traceback (most recent call last):
  File "/home/marcus/cbang/config/python/python-config.py", line 7, in <module>
    from distutils import sysconfig
ImportError: cannot import name 'sysconfig' from 'distutils' (/usr/lib/python3.7/distutils/__init__.py)
/bin/sh: 1: pkg-config: not found
OSError: 'pkg-config Qt5Core Qt5Gui Qt5OpenGL Qt5Network Qt5Widgets Qt5WebSockets --libs --cflags' exited 127:
  File "/home/marcus/CAMotics/SConstruct", line 96:
    env.EnableQtModules(qtmods.split())
  File "/usr/lib/scons/SCons/Environment.py", line 224:
    return self.method(*nargs, **kwargs)
  File "/home/marcus/CAMotics/config/qt5/__init__.py", line 965:
    self.ParseConfig('pkg-config %s --libs --cflags' % ' '.join(pcmodules))
  File "/usr/lib/scons/SCons/Environment.py", line 1557:
    return function(self, self.backtick(command))
  File "/usr/lib/scons/SCons/Environment.py", line 594:
    raise OSError("'%s' exited %d" % (command, status))
```

Adding `pkgconf` to the deps allows building.
