### PR TITLE
Fix user-facing (and non-user facing) typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
  - Show feed in project units. (hpmachining)
  - Handle long or even infinite GCode programs better.
  - Implemented M70-M73
- - More direct prespective view.
+ - More direct perspective view.
  - Fixed view reset during rotation bug.
  - Added Ctrl-R for reload/run.
  - Fixed recent projects list.
@@ -140,7 +140,7 @@
  - Allow exporting GCode from GUI
  - Ability to run simulations from the command line
  - Fixed STL export in Windows #81
- - Fixed problems runing with different locale settings #100
+ - Fixed problems running with different locale settings #100
  - Fixed v8 linking problems
  - Fixed problems with automatic workpiece z-axis #105
  - Fixed filename problems when opening and saving files #87
@@ -212,7 +212,7 @@
  - Added icut() and irapid().
  - Fixed play/pause button update.
  - Added loop check box, off by default.
- - Display "inf" when time is infinate due to zero feed.
+ - Display "inf" when time is infinite due to zero feed.
 
 ## v0.1.2:
 
@@ -253,7 +253,7 @@
 
  - Automatically calculate render resolution based on workpiece.  #3
  - Don't allow unquoted expressions in assignment, not allowed by LinuxCNC.
- - Don't execute an implict motion if a non-modal group 0 code is issued.
+ - Don't execute an implicit motion if a non-modal group 0 code is issued.
  - Fixed global offsets.  G92, G92.1, G92.2, G92.3
  - Added stretching cat array example.
  - Correctly implement named local/global variables in sub routines.
@@ -275,7 +275,7 @@
 
 2012-02-18
 
- - Case insenstive G-Code.
+ - Case insensitive G-Code.
  - Detect G-Code vs. project files on command line.  #36
  - Compute angle functions in degrees not radians.
  - Fixed operator associativity.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ you can try.
   - SCons      - http://www.scons.org/
   - v8         - https://developers.google.com/v8/
 
-On Debian based systems all the prerequisites, including thoese needed
+On Debian based systems all the prerequisites, including those needed
 by C!, can be installed with the following command line:
 
     sudo apt-get update

--- a/examples/genes-encoder/genes-encoder.ngc
+++ b/examples/genes-encoder/genes-encoder.ngc
@@ -6,7 +6,7 @@
 ( This encoder ring mounts on the lathe spindle drive pulley. )
 ( Ring encoder provides A,B,Z phases using 3 H21TLB slot sensors. )
 ( The H21TLB sensor use 5v and can directly drive parallel port pins. )
-( The sensor apeture is 0.035", so I used double that for the slot length )
+( The sensor aperture is 0.035", so I used double that for the slot length )
 ( to allow for some runout on mounting the ring. )
 ( The main constraint is that the main track opto has to be able to physically )
 ( read the inner track... reaching over the outer index track )
@@ -122,7 +122,7 @@ o10 do
   #<myx> = [#<inner_dia>/2.0 * cos[#<myangle>]]
   #<myy> = [#<inner_dia>/2.0 * sin[#<myangle>]]
   g0 z[#<_ztmp> - #<_zinc>]
-  g1 x[#<myx>] y[#<myy>] z[#<_ztmp>] f[#<_feedrate>]  ( decend to cut depth )
+  g1 x[#<myx>] y[#<myy>] z[#<_ztmp>] f[#<_feedrate>]  ( descend to cut depth )
 
   #<myangle> = [#<angle> + [#<slot_deg>/2.0] - [#<icutter_deg>/2.0]]
   #<myx> = [#<inner_dia>/2.0 * cos[#<myangle>]]
@@ -170,7 +170,7 @@ g0 x[#<centerx>] y[#<centery>]
 #<myx> = [#<inner_dia>/2.0 * cos[#<myangle>]]
 #<myy> = [#<inner_dia>/2.0 * sin[#<myangle>]]
 g0 z[#<_ztmp> - #<_zinc>]
-g1 x[#<myx>] y[#<myy>] z[#<_ztmp>] f[#<_feedrate>]  ( decend to cut depth )
+g1 x[#<myx>] y[#<myy>] z[#<_ztmp>] f[#<_feedrate>]  ( descend to cut depth )
 
 #<myangle> = [#<angle> + [#<slot_deg>/2.0] - [#<icutter_deg>/2.0]]
 #<myx> = [#<inner_dia>/2.0 * cos[#<myangle>]]

--- a/qt/camotics.ui
+++ b/qt/camotics.ui
@@ -3049,7 +3049,7 @@
     <string>Save Tool Table &amp;As Default</string>
    </property>
    <property name="toolTip">
-    <string>Save curent tool table as default</string>
+    <string>Save current tool table as default</string>
    </property>
   </action>
   <action name="actionLoadDefaultToolTable">

--- a/qt/new_dialog.ui
+++ b/qt/new_dialog.ui
@@ -38,7 +38,7 @@
       <item>
        <widget class="QRadioButton" name="newTPLRadioButton">
         <property name="toolTip">
-         <string>Create a new TPL file by selecting a non-existing filename or select an exsiting TPL file and add it to the current project.</string>
+         <string>Create a new TPL file by selecting a non-existing filename or select an existing TPL file and add it to the current project.</string>
         </property>
         <property name="text">
          <string>TPL File (Tool Path Language)</string>
@@ -51,7 +51,7 @@
       <item>
        <widget class="QRadioButton" name="newGCodeRadioButton">
         <property name="toolTip">
-         <string>Create a new GCode file by selecting a non-existing filename or select an exsiting GCode file and add it to the current project.</string>
+         <string>Create a new GCode file by selecting a non-existing filename or select an existing GCode file and add it to the current project.</string>
         </property>
         <property name="text">
          <string>G-Code File</string>

--- a/src/camotics/contour/QEF.cpp
+++ b/src/camotics/contour/QEF.cpp
@@ -43,7 +43,7 @@ Vector3D QEF::evaluate(double mat[12][3], double vec[12], int rows) {
   //   u is a matrix of rows x 3 (same as mat);
   //   v is a square matrix 3 x 3 (for 3 columns in mat);
   //   d is vector of 3 values representing the diagonal matrix 3 x 3
-  //     (for 3 colums in mat).
+  //     (for 3 columns in mat).
   double u[MAXROWS][3], v[3][3], d[3];
 
   computeSVD(mat, u, v, d, rows);
@@ -535,7 +535,7 @@ void QEF::qrstep_cols2(double u[12][3], double v[3][3], double tau_u[3],
       v[i][1] = vip * s + viq * c;
     }
 
-  } else { // make colums orthogonal
+  } else { // make columns orthogonal
     double c, s;
 
     // perform Schur rotation on B

--- a/src/camotics/contour/QEF.h
+++ b/src/camotics/contour/QEF.h
@@ -37,7 +37,7 @@ namespace CAMotics {
    *      E[x] = P - Ni . Pi
    *
    * Given at least three points Pi, each with its respective normal
-   * vector Ni, that describe at least two planes, the QEF evalulates
+   * vector Ni, that describe at least two planes, the QEF evaluates
    * to the point x.
    */
   class QEF {

--- a/src/camotics/qt/FileDialog.cpp
+++ b/src/camotics/qt/FileDialog.cpp
@@ -38,7 +38,7 @@ FileDialog::FileDialog(QtWin &win) : win(win) {}
 
 QString FileDialog::open(const QString &title, const QString &filters,
                          const QString &filename, bool save, bool anyFile) {
-  // Find a resonable directory & file to start from
+  // Find a reasonable directory & file to start from
   QString qPath = filename;
 
   if (qPath.isEmpty()) {

--- a/src/camotics/qt/FileTabManager.cpp
+++ b/src/camotics/qt/FileTabManager.cpp
@@ -135,7 +135,7 @@ bool FileTabManager::checkSave(unsigned tab) {
 
   int response =
     QMessageBox::question(this, "File Modified", "The current file has "
-                          "been modifed.  Would you like to save it?",
+                          "been modified.  Would you like to save it?",
                           QMessageBox::Cancel | QMessageBox::No |
                           QMessageBox::Yes, QMessageBox::Yes);
 
@@ -157,7 +157,7 @@ bool FileTabManager::checkSaveAll() {
 
           int response =
             QMessageBox::question(this, "File Modified", "The current file has "
-                                  "been modifed.  Would you like to save?",
+                                  "been modified.  Would you like to save?",
                                   QMessageBox::Cancel | QMessageBox::No |
                                   QMessageBox::Save | QMessageBox::SaveAll,
                                   QMessageBox::SaveAll);

--- a/src/camotics/qt/QtWin.cpp
+++ b/src/camotics/qt/QtWin.cpp
@@ -1262,7 +1262,7 @@ bool QtWin::checkSave(bool canCancel) {
 
   int response =
     QMessageBox::question(this, "Project Modified", "The current project has "
-                          "been modifed.  Would you like to save it?",
+                          "been modified.  Would you like to save it?",
                           (canCancel ?
                            QMessageBox::Cancel : QMessageBox::NoButton) |
                           QMessageBox::No | QMessageBox::Yes, QMessageBox::Yes);

--- a/src/camotics/value/Value.h
+++ b/src/camotics/value/Value.h
@@ -38,7 +38,7 @@ namespace CAMotics {
 
   public:
     Value(const std::string &name) : name(name) {}
-    virtual ~Value() {} // Complier needs this
+    virtual ~Value() {} // Compiler needs this
 
     const std::string &getName() const {return name;}
     void add(const cb::SmartPointer<Observer> &o) {observers.push_back(o);}

--- a/src/camotics/view/GLProgram.cpp
+++ b/src/camotics/view/GLProgram.cpp
@@ -93,7 +93,7 @@ void GLProgram::link() {
     THROW("Failed to link GL program: " << &error[0]);
   }
 
-  // Detatch all shaders
+  // Detach all shaders
   GLint count;
   gl.glGetProgramiv(program, GL_ATTACHED_SHADERS, &count);
 

--- a/src/gcode/machine/MachineInterface.h
+++ b/src/gcode/machine/MachineInterface.h
@@ -70,7 +70,7 @@ namespace GCode {
      */
     virtual void setFeedMode(feed_mode_t mode) = 0;
 
-    /// @return the currently programed spindle speed.
+    /// @return the currently programmed spindle speed.
     virtual double getSpeed() const = 0;
 
     /***
@@ -82,7 +82,7 @@ namespace GCode {
     virtual void setSpeed(double speed) = 0;
 
     /***
-     * @return the currently programed spin mode and optionally the max speed.
+     * @return the currently programmed spin mode and optionally the max speed.
      */
     virtual spin_mode_t getSpinMode(double *max = 0) const = 0;
 
@@ -94,7 +94,7 @@ namespace GCode {
      * spindle speed in meters per minute.
      *
      * If @param mode is CONSTANT_SURFACE_SPEED and @param max is greater than
-     * zero then @param max is the maxiumum spindle revolutions per minute.
+     * zero then @param max is the maximum spindle revolutions per minute.
      *
      * @throw cb::Exception @param mode is invalid.
      */
@@ -122,9 +122,9 @@ namespace GCode {
      * Wait for input change.
      *
      * @param port the input port to input on.
-     * @param mode one of IMEDIATE, RISE, FALL, HIGH or LOW
+     * @param mode one of IMMEDIATE, RISE, FALL, HIGH or LOW
      * @param timeout the maximum amount of time to input or zero to input
-     *   indefinately.  It is an error of the port does not change to the
+     *   indefinitely.  It is an error of the port does not change to the
      *   specified state before the timeout expires.
      */
     virtual void input(port_t port, input_mode_t mode, double timeout) = 0;

--- a/src/gcode/machine/MachineUnitAdapter.h
+++ b/src/gcode/machine/MachineUnitAdapter.h
@@ -42,7 +42,7 @@ namespace GCode {
     bool isImperial() const {return units == IMPERIAL;}
     void setImperial() {setUnits(IMPERIAL);}
 
-    /// @return the currently programed units.
+    /// @return the currently programmed units.
     Units getUnits() const {return units;}
 
     /***

--- a/src/gcode/plan/LinePlanner.cpp
+++ b/src/gcode/plan/LinePlanner.cpp
@@ -668,7 +668,7 @@ bool LinePlanner::isFinal(PlannerCommand *cmd) const {
   if (velocity <= Math::nextUp(0)) return true;
 
   // Check if there is enough velocity change in the following blocks to
-  // deccelerate to zero if necessary.
+  // decelerate to zero if necessary.
   unsigned count = 0;
   while (cmd->next) {
     cmd = cmd->next;
@@ -687,7 +687,7 @@ bool LinePlanner::isFinal(PlannerCommand *cmd) const {
         count++;
 
         if (cmd->getExitVelocity() <= velocity) {
-          LOG_DEBUG(3, "Hit lookahead limit but successfuly planed reverse "
+          LOG_DEBUG(3, "Hit lookahead limit but successfully planned reverse "
                     "speed up from zero to " << cmd->getExitVelocity()
                     << " in " << count << " moves");
 
@@ -727,7 +727,7 @@ bool LinePlanner::planOne(PlannerCommand *cmd) {
   LOG_DEBUG(3, "Planning " << cmd->getID());
   LOG_DEBUG(4, "Planning " << cmd->toString());
 
-  // Set entry velocity when at begining
+  // Set entry velocity when at beginning
   bool backplan = false;
   if (!cmd->prev) cmd->setEntryVelocity(lastExitVel);
 

--- a/tests/tplTests/SquareTest/data/stdin
+++ b/tests/tplTests/SquareTest/data/stdin
@@ -9,7 +9,7 @@ cut({z: -3}); // Cut down to depth
 cut({x: 11}); // Cut to second corner
 cut({y: 11}); // Cut to third corner
 cut({x: 1}); // Cut to forth corner
-cut({y: 1}); // Cut back to begining
+cut({y: 1}); // Cut back to beginning
 
 rapid({z: 5}); // Move back to safe position
 speed(0); // Stop spinning

--- a/tests/tplTests/SquaresTest/data/stdin
+++ b/tests/tplTests/SquaresTest/data/stdin
@@ -3,7 +3,7 @@ function square(size, depth, safe) {
   icut({x: size}); // Cut to second corner
   icut({y: size}); // Cut to third corner
   icut({x: -size}); // Cut to forth corner
-  icut({y: -size}); // Cut back to begining
+  icut({y: -size}); // Cut back to beginning
   rapid({z: safe}); // Move back to safe position
 }
 

--- a/tests/tplTests/StarTest/data/stdin
+++ b/tests/tplTests/StarTest/data/stdin
@@ -3,7 +3,7 @@ function square(size, depth, safe) {
   icut({x: size}); // Cut to second corner
   icut({y: size}); // Cut to third corner
   icut({x: -size}); // Cut to forth corner
-  icut({y: -size}); // Cut back to begining
+  icut({y: -size}); // Cut back to beginning
   rapid({z: safe}); // Move back to safe position
 }
 


### PR DESCRIPTION
Found via `codespell v2.1.dev0`  
`codespell -q 3 -S ./src/cairo,./src/dxflib,./src/clipper,tpl_lib,*.ts -L ba,pard,parm,trough`