### PR TITLE
Fix build failure when "with_tpl=false"

### DIFF
--- a/src/camotics/sim/ToolPathTask.cpp
+++ b/src/camotics/sim/ToolPathTask.cpp
@@ -94,6 +94,7 @@ ToolPathTask::~ToolPathTask() {interrupt();}
 
 
 void ToolPathTask::runTPL(const InputSource &src) {
+#if defined(HAVE_V8) || defined(HAVE_CHAKRA)
   Task::begin("Running TPL");
 
   tplCtx =
@@ -113,6 +114,7 @@ void ToolPathTask::runTPL(const InputSource &src) {
   errors++;
 
   tplCtx.release();
+#endif
 }
 
 


### PR DESCRIPTION
Fixes build failure on code that depends on tpl when the with_tpl flag is set to false.