### PR TITLE
Fix to build with c++17 standard

### DIFF
--- a/src/camotics/contour/TriangleMesh.h
+++ b/src/camotics/contour/TriangleMesh.h
@@ -52,7 +52,7 @@ namespace CAMotics {
 
 
     struct VertexSort {
-      bool operator() (const Vertex *a, const Vertex *b) {return *a < *b;}
+      bool operator() (const Vertex *a, const Vertex *b) const {return *a < *b;}
     };
 
 


### PR DESCRIPTION
Need to use c++17 standard with latest v8.

I needed to build with c++17 standard to get cbang and camotics to build against the latest V8 (10.5.84). cbang built fine without changes, but I needed to make this change to get camotics to build. 