### PR TITLE
- Moved 'machines' to /usr/share/camotics

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -277,8 +277,8 @@ Clean(execs, ['build', 'config.log', 'dist.txt', 'package.txt'])
 prefix = env.get('install_prefix')
 env.Alias('install', [prefix])
 
-for target in docs + ['examples', 'machines']:
-    env.Install(prefix + '/share/doc/camotics/', target)
+env.Install(prefix + '/share/doc/camotics/', 'examples')
+env.Install(prefix + '/share/camotics/', 'machines')
 
 env.Install(prefix + '/share/camotics/', 'tpl_lib')
 env.Install(prefix + '/share/pixmaps', 'images/camotics.png')

--- a/SConstruct
+++ b/SConstruct
@@ -277,9 +277,11 @@ Clean(execs, ['build', 'config.log', 'dist.txt', 'package.txt'])
 prefix = env.get('install_prefix')
 env.Alias('install', [prefix])
 
-env.Install(prefix + '/share/doc/camotics/', 'examples')
-env.Install(prefix + '/share/camotics/', 'machines')
+for target in docs + ['examples']:
+    env.Install(prefix + '/share/doc/camotics/', target)
 
+
+env.Install(prefix + '/share/camotics/', 'machines')
 env.Install(prefix + '/share/camotics/', 'tpl_lib')
 env.Install(prefix + '/share/pixmaps', 'images/camotics.png')
 env.Install(prefix + '/share/applications', 'CAMotics.desktop')

--- a/SConstruct
+++ b/SConstruct
@@ -286,6 +286,8 @@ env.Install(prefix + '/share/camotics/', 'tpl_lib')
 env.Install(prefix + '/share/pixmaps', 'images/camotics.png')
 env.Install(prefix + '/share/applications', 'CAMotics.desktop')
 env.InstallAs(prefix + '/share/mime/packages/camotics.xml', 'mime.xml')
+env.Install(prefix + '/share/appdata/', 'CAMotics.appdata.xml')
+env.Install(prefix + '/share/icons/hicolor/128x128/apps/', 'images/camotics.png')
 
 description = '''CAMotics is an Open-Source software which can simulate
 3-axis NC machining. It is a fast, flexible and user friendly simulation

--- a/src/camotics/qt/QtWin.cpp
+++ b/src/camotics/qt/QtWin.cpp
@@ -372,9 +372,15 @@ void QtWin::loadMachine(const string &machine) {
 void QtWin::loadMachines() {
   try {
     vector<string> paths;
-    paths.push_back(SystemUtilities::getPathPrefix() +
-                    "/share/doc/camotics/machines");
+
+    QStringList list = QStandardPaths::locateAll(QStandardPaths::GenericDataLocation, "camotics/machines", QStandardPaths::LocateDirectory);
+    for (int i = 0; i < list.size(); i++)
+      paths.push_back(list .at(i).toUtf8().constData());
+
+#ifdef __APPLE__
     paths.push_back("../SharedSupport/machines");
+#endif
+
     paths.push_back("machines");
 
     string root = ".";
@@ -387,7 +393,6 @@ void QtWin::loadMachines() {
       if (path[0] != '/') path = root + "/" + path;
 
       if (SystemUtilities::isDirectory(path)) {
-        unsigned count = 0;
         DirectoryWalker walker(path, ".*\\.json", 1);
 
         while (walker.hasNext()) {
@@ -397,12 +402,9 @@ void QtWin::loadMachines() {
             SmartPointer<JSON::Value> data = JSON::Reader::parse(filename);
             if (!data->hasString("name") || !data->hasString("model")) continue;
 
-            count++;
             settingsDialog.addMachine(data->getString("name"), filename);
           } CATCH_ERROR;
         }
-
-        if (count) break;
       }
     }
 

--- a/src/camotics/qt/SettingsDialog.cpp
+++ b/src/camotics/qt/SettingsDialog.cpp
@@ -43,8 +43,9 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
 
 
 void SettingsDialog::addMachine(const string &name, const string &path) {
-  ui->machineComboBox->addItem(QString::fromUtf8(name.c_str()),
-                               QString::fromUtf8(path.c_str()));
+  if (ui->machineComboBox->findText(QString::fromUtf8(name.c_str())) < 0)
+    ui->machineComboBox->addItem(QString::fromUtf8(name.c_str()),
+                                QString::fromUtf8(path.c_str()));
 }
 
 


### PR DESCRIPTION
- Moved 'machines' to /usr/share/camotics
- Updated 'machines' directory search
- Avoid duplicates in 'machines' combobox

Rationale: 
'machines' is a kind of library, not a documentation, thus more appropriate place to store it is /usr/share/camotics.
Also, it is more convenient to have any user-modified files to be stored in their profiles and their work is not lost by updates, so the search through all known directories is needed.