### PR TITLE
BugFix: DL_Dxf::in requires pointer to DL_CreationInterface

### DIFF
--- a/config/dxflib/__init__.py
+++ b/config/dxflib/__init__.py
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
   DL_CreationAdapter adapter;
 
   // Test for acceptance of std::istream in API
-  dxf.in(std::cin, adapter);
+  dxf.in(std::cin, &adapter);
 
   return 0;
 }


### PR DESCRIPTION
The dxflib configure compilation test always fails due to typo