### PR TITLE
Add osx entitlements

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -438,7 +438,8 @@ if 'package' in COMMAND_LINE_TARGETS:
         rpm_obsoletes = 'openscam',
 
         app_id = 'org.camotics.CAMotics',
-        app_resources = [['osx/Resources', '.'], ['tpl_lib', 'tpl_lib']],
+        app_resources = [['osx/Resources', '.'], ['tpl_lib', 'tpl_lib'],
+                        ['osx/entitlements.plist', '.']],
         app_copyright = env['PACKAGE_COPYRIGHT'],
         app_signature = 'camo',
         app_other_info = {

--- a/osx/entitlements.plist
+++ b/osx/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/osx/pkg.plist
+++ b/osx/pkg.plist
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <array>
     <dict>
       <key>BundleHasStrictIdentifier</key>
-      <true/>
+      <false/>
       <key>BundleIsRelocatable</key>
       <false/>
       <key>BundleIsVersionChecked</key>
@@ -14,8 +13,6 @@
       <string>upgrade</string>
       <key>RootRelativeBundlePath</key>
       <string>Applications/CAMotics.app</string>
-      <key>BundlePostInstallScriptPath</key>
-      <string>postinstall</string>
     </dict>
   </array>
 </plist>


### PR DESCRIPTION
Add osx entitlements for hardened runtime
Sandbox disabled, because CAMotics doesn't like
Update pkg.plist non-strict bundle id
Remove explicit default postinstall script name