### PR TITLE
Fix various typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,7 @@
  - Fixed file dialog modality problem. #27
  - Display ETA during rendering. #25
  - Fixed: Adding an NC file to a new project causes crash.  #26
- - Allow gcode program delimter '%'.
+ - Allow gcode program delimiter '%'.
  - Default tool length to 1.
  - Fix: Adding an NC file to a new project gives it an absolute path.  #30
  - Fix: Saving project causes duplicate nc file entries in .xml.  #29

--- a/buildbot/JSONBuildmasterConfig/JSONBuildmasterConfig.py
+++ b/buildbot/JSONBuildmasterConfig/JSONBuildmasterConfig.py
@@ -80,7 +80,7 @@ def _render_env(props, env, translate_var_refs):
 
     else: value = render(value)
 
-    # Subsitute variable references
+    # Substitute variable references
     if translate_var_refs:
       if value is not None: value = pat.sub(subst, value)
 

--- a/doc/research/tool_sweep/camotics_3_axis_cnc_simulation.tex
+++ b/doc/research/tool_sweep/camotics_3_axis_cnc_simulation.tex
@@ -73,7 +73,7 @@ Vs. octree.
 \section{Icons}
 \section{Qt Creator}
 
-\chapter{Slice Optimzation}
+\chapter{Slice Optimization}
 \chapter{Triangle Reduction}
 
 \end{appendices}

--- a/languages/README.md
+++ b/languages/README.md
@@ -6,7 +6,7 @@ First update the translation files with:
 
     lupdate qt/*.ui src/camotics/qt/*.cpp -ts languages/*.ts
 
-Then use ``linguist`` from the Qt pacakge to edit the ``.ts`` files in
+Then use ``linguist`` from the Qt package to edit the ``.ts`` files in
 ``translations``.
 
 Finally, rebuild the software.

--- a/src/camotics/sim/ToolSweep.cpp
+++ b/src/camotics/sim/ToolSweep.cpp
@@ -112,7 +112,7 @@ double ToolSweep::depth(const Vector3D &p) const {
   vector<const GCode::Move *> moves;
   collisions(p, moves);
 
-  // Eariler moves first
+  // Earlier moves first
   sort(moves.begin(), moves.end(), move_sort());
 
   double d2 = -numeric_limits<double>::max();


### PR DESCRIPTION
Found via `codespell -q 3 -S ./src/cairo,./src/dxflib,./src/clipper,tpl_lib,*.ts -L ba,pard,parm,trough`

Note some source documentation has been modified.