### PR TITLE
Add support for syncing code to simulation

### DIFF
--- a/qt/camotics.ui
+++ b/qt/camotics.ui
@@ -7,8 +7,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1004</width>
-    <height>815</height>
+    <width>1437</width>
+    <height>869</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,22 +27,7 @@
    <property name="styleSheet">
     <string notr="true"/>
    </property>
-   <layout class="QVBoxLayout" name="verticalLayout_25">
-    <property name="spacing">
-     <number>0</number>
-    </property>
-    <property name="leftMargin">
-     <number>0</number>
-    </property>
-    <property name="topMargin">
-     <number>0</number>
-    </property>
-    <property name="rightMargin">
-     <number>0</number>
-    </property>
-    <property name="bottomMargin">
-     <number>0</number>
-    </property>
+   <layout class="QVBoxLayout" name="verticalLayout_16">
     <item>
      <widget class="QSplitter" name="splitter">
       <property name="orientation">
@@ -51,127 +36,250 @@
       <property name="handleWidth">
        <number>6</number>
       </property>
-      <widget class="QWidget" name="layoutWidget">
-       <layout class="QVBoxLayout" name="verticalLayout_7">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="CAMotics::FileTabManager" name="fileTabManager">
-          <property name="currentIndex">
-           <number>0</number>
-          </property>
-          <widget class="QWidget" name="simulationTab">
-           <property name="styleSheet">
-            <string notr="true">QPushButton:hover {
-  border: 1px outset #71869c;
-  border-radius: 2px;
-  background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                 stop: 0 #c5d3df, stop: 1 #b2c1d1);
-} </string>
+      <widget class="QSplitter" name="splitterFile">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="handleWidth">
+        <number>6</number>
+       </property>
+       <widget class="QWidget" name="verticalLayoutWidget">
+        <layout class="QVBoxLayout" name="verticalLayout_15">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="CAMotics::GLView" name="simulationView" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
            </property>
-           <attribute name="title">
-            <string>Simulation View</string>
-           </attribute>
-           <layout class="QVBoxLayout" name="verticalLayout_9">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="CAMotics::GLView" name="simulationView" native="true">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>1</horstretch>
-                <verstretch>1</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>200</height>
-               </size>
-              </property>
-              <property name="contextMenuPolicy">
-               <enum>Qt::CustomContextMenu</enum>
-              </property>
-              <property name="layoutDirection">
-               <enum>Qt::LeftToRight</enum>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <layout class="QGridLayout" name="gridLayout_9">
-              <property name="horizontalSpacing">
-               <number>6</number>
-              </property>
-              <item row="0" column="1">
-               <widget class="QSlider" name="positionSlider">
-                <property name="focusPolicy">
-                 <enum>Qt::NoFocus</enum>
-                </property>
-                <property name="toolTip">
-                 <string>Set tool path position</string>
-                </property>
-                <property name="maximum">
-                 <number>10000</number>
-                </property>
-                <property name="singleStep">
-                 <number>10</number>
-                </property>
-                <property name="pageStep">
-                 <number>100</number>
-                </property>
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_28">
-                <property name="minimumSize">
-                 <size>
-                  <width>70</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>70</width>
-                  <height>16777215</height>
-                 </size>
-                </property>
-                <property name="font">
-                 <font>
-                  <underline>true</underline>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Position</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>200</height>
+            </size>
+           </property>
+           <property name="contextMenuPolicy">
+            <enum>Qt::CustomContextMenu</enum>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LeftToRight</enum>
+           </property>
           </widget>
-         </widget>
-        </item>
-       </layout>
+         </item>
+         <item>
+          <layout class="QGridLayout" name="gridLayout_9">
+           <property name="horizontalSpacing">
+            <number>6</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_28">
+             <property name="minimumSize">
+              <size>
+               <width>70</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>70</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <underline>true</underline>
+              </font>
+             </property>
+             <property name="text">
+              <string>Position</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSlider" name="positionSlider">
+             <property name="focusPolicy">
+              <enum>Qt::NoFocus</enum>
+             </property>
+             <property name="toolTip">
+              <string>Set tool path position</string>
+             </property>
+             <property name="maximum">
+              <number>10000</number>
+             </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="pageStep">
+              <number>100</number>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="layoutWidget">
+        <layout class="QVBoxLayout" name="verticalLayout_7">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="CAMotics::FileTabManager" name="fileTabManager">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="tabPosition">
+            <enum>QTabWidget::West</enum>
+           </property>
+           <property name="tabShape">
+            <enum>QTabWidget::Triangular</enum>
+           </property>
+           <property name="currentIndex">
+            <number>0</number>
+           </property>
+           <property name="elideMode">
+            <enum>Qt::ElideNone</enum>
+           </property>
+           <property name="documentMode">
+            <bool>false</bool>
+           </property>
+           <property name="tabsClosable">
+            <bool>false</bool>
+           </property>
+           <property name="movable">
+            <bool>false</bool>
+           </property>
+           <property name="tabBarAutoHide">
+            <bool>false</bool>
+           </property>
+           <widget class="QWidget" name="commentTab">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="styleSheet">
+             <string notr="true"/>
+            </property>
+            <attribute name="title">
+             <string>Project Comment</string>
+            </attribute>
+            <layout class="QVBoxLayout" name="verticalLayout_9">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QTextEdit" name="commentTextEdit">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="syncCheckBox">
+           <property name="text">
+            <string>Sync Text Editor to Simulation</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
       <widget class="QWidget" name="layoutWidget1">
        <layout class="QVBoxLayout" name="consoleFrame">
@@ -309,7 +417,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1004</width>
+     <width>1437</width>
      <height>23</height>
     </rect>
    </property>
@@ -397,6 +505,7 @@
     <addaction name="actionZoomIn"/>
     <addaction name="actionZoomAll"/>
     <addaction name="actionToggleConsole"/>
+    <addaction name="actionToggleText"/>
    </widget>
    <widget class="QMenu" name="menuSimulate">
     <property name="title">
@@ -565,7 +674,7 @@
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
-    <string>Tool Position</string>
+    <string>Tool Positio&amp;n</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -811,6 +920,7 @@
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
               <underline>true</underline>
              </font>
@@ -828,6 +938,7 @@
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
               <underline>true</underline>
              </font>
@@ -851,6 +962,7 @@
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
               <underline>true</underline>
              </font>
@@ -891,6 +1003,7 @@
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
               <underline>true</underline>
              </font>
@@ -931,6 +1044,7 @@
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
               <underline>true</underline>
              </font>
@@ -971,6 +1085,7 @@
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
               <underline>true</underline>
              </font>
@@ -1019,7 +1134,7 @@
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
-    <string>Machine Status</string>
+    <string>&amp;Machine Status</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -1070,8 +1185,8 @@
           <property name="rightMargin">
            <number>0</number>
           </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_30">
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_34">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -1081,52 +1196,13 @@
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
               <underline>true</underline>
              </font>
             </property>
             <property name="text">
-             <string>Tool</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="toolLabel">
-            <property name="text">
-             <string>0</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_31">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>12</pointsize>
-              <bold>false</bold>
-              <underline>true</underline>
-             </font>
-            </property>
-            <property name="text">
-             <string>Feed</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="feedLabel">
-            <property name="text">
-             <string>0.0</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             <string>Program Name</string>
             </property>
            </widget>
           </item>
@@ -1141,6 +1217,7 @@
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
               <underline>true</underline>
              </font>
@@ -1160,6 +1237,16 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="toolLabel">
+            <property name="text">
+             <string>0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="label_33">
             <property name="sizePolicy">
@@ -1171,12 +1258,44 @@
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
               <underline>true</underline>
              </font>
             </property>
             <property name="text">
              <string>Spin</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="feedLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_31">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
+              <weight>50</weight>
+              <bold>false</bold>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="text">
+             <string>Feed</string>
             </property>
            </widget>
           </item>
@@ -1190,8 +1309,8 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_34">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_30">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -1201,7 +1320,27 @@
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="text">
+             <string>Tool</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_25">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
               <underline>true</underline>
              </font>
             </property>
@@ -1210,10 +1349,20 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QLabel" name="programLineLabel">
             <property name="text">
              <string>0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="programNameLabel">
+            <property name="text">
+             <string/>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1242,7 +1391,7 @@
     <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>
    </property>
    <property name="windowTitle">
-    <string>Files</string>
+    <string>F&amp;iles</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>1</number>
@@ -1291,7 +1440,7 @@
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
-    <string>Tool Path Bounds</string>
+    <string>Tool Path Bo&amp;unds</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -1529,7 +1678,7 @@
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
-    <string>Workpiece Bounds</string>
+    <string>Wor&amp;kpiece Bounds</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -2364,7 +2513,7 @@
      <normaloff>:/icons/wire.png</normaloff>:/icons/wire.png</iconset>
    </property>
    <property name="text">
-    <string>Show Wire Surface</string>
+    <string>Show &amp;Wire Surface</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+2</string>
@@ -2421,7 +2570,7 @@
      <normaloff>:/icons/cut_surface.png</normaloff>:/icons/cut_surface.png</iconset>
    </property>
    <property name="text">
-    <string>Show Cut Surface</string>
+    <string>&amp;Show Cut Surface</string>
    </property>
    <property name="toolTip">
     <string>Show cut surface</string>
@@ -2442,7 +2591,7 @@
      <normaloff>:/icons/axes.png</normaloff>:/icons/axes.png</iconset>
    </property>
    <property name="text">
-    <string>Show Axes</string>
+    <string>Show A&amp;xes</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+8</string>
@@ -2460,7 +2609,7 @@
      <normaloff>:/icons/path.png</normaloff>:/icons/path.png</iconset>
    </property>
    <property name="text">
-    <string>Show Tool Path</string>
+    <string>Show Tool &amp;Path</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+5</string>
@@ -2472,7 +2621,7 @@
      <normaloff>:/icons/isometric.png</normaloff>:/icons/isometric.png</iconset>
    </property>
    <property name="text">
-    <string>Isometric</string>
+    <string>&amp;Isometric</string>
    </property>
    <property name="toolTip">
     <string>Snap to isometric view</string>
@@ -2487,7 +2636,7 @@
      <normaloff>:/icons/front.png</normaloff>:/icons/front.png</iconset>
    </property>
    <property name="text">
-    <string>Front</string>
+    <string>Fro&amp;nt</string>
    </property>
    <property name="toolTip">
     <string>Snap to front view</string>
@@ -2502,7 +2651,7 @@
      <normaloff>:/icons/back.png</normaloff>:/icons/back.png</iconset>
    </property>
    <property name="text">
-    <string>Back</string>
+    <string>&amp;Back</string>
    </property>
    <property name="toolTip">
     <string>Snap to back view</string>
@@ -2517,7 +2666,7 @@
      <normaloff>:/icons/left.png</normaloff>:/icons/left.png</iconset>
    </property>
    <property name="text">
-    <string>Left</string>
+    <string>&amp;Left</string>
    </property>
    <property name="toolTip">
     <string>Snap to left view</string>
@@ -2532,7 +2681,7 @@
      <normaloff>:/icons/right.png</normaloff>:/icons/right.png</iconset>
    </property>
    <property name="text">
-    <string>Right</string>
+    <string>&amp;Right</string>
    </property>
    <property name="toolTip">
     <string>Snap to right view</string>
@@ -2547,7 +2696,7 @@
      <normaloff>:/icons/top.png</normaloff>:/icons/top.png</iconset>
    </property>
    <property name="text">
-    <string>Top</string>
+    <string>T&amp;op</string>
    </property>
    <property name="toolTip">
     <string>Snap to top view</string>
@@ -2577,7 +2726,7 @@
      <normaloff>:/icons/slower.png</normaloff>:/icons/slower.png</iconset>
    </property>
    <property name="text">
-    <string>Slower</string>
+    <string>S&amp;lower</string>
    </property>
    <property name="toolTip">
     <string>Slow down tool path animation</string>
@@ -2589,7 +2738,7 @@
      <normaloff>:/icons/play.png</normaloff>:/icons/play.png</iconset>
    </property>
    <property name="text">
-    <string>Play</string>
+    <string>&amp;Play</string>
    </property>
    <property name="toolTip">
     <string>Start or stop tool path animation</string>
@@ -2601,7 +2750,7 @@
      <normaloff>:/icons/faster.png</normaloff>:/icons/faster.png</iconset>
    </property>
    <property name="text">
-    <string>Faster</string>
+    <string>&amp;Faster</string>
    </property>
    <property name="toolTip">
     <string>Speed up tool path animation</string>
@@ -2613,7 +2762,7 @@
      <normaloff>:/icons/forward.png</normaloff>:/icons/forward.png</iconset>
    </property>
    <property name="text">
-    <string>Direction</string>
+    <string>&amp;Direction</string>
    </property>
    <property name="toolTip">
     <string>Change tool path animation direction</string>
@@ -2676,7 +2825,7 @@
      <normaloff>:/icons/no-surface.png</normaloff>:/icons/no-surface.png</iconset>
    </property>
    <property name="text">
-    <string>Hide Surface</string>
+    <string>&amp;Hide Surface</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+4</string>
@@ -2688,7 +2837,7 @@
      <normaloff>:/icons/stop.png</normaloff>:/icons/stop.png</iconset>
    </property>
    <property name="text">
-    <string>Stop</string>
+    <string>&amp;Stop</string>
    </property>
    <property name="toolTip">
     <string>Stop the simulation</string>
@@ -2703,7 +2852,7 @@
      <normaloff>:/icons/restart.png</normaloff>:/icons/restart.png</iconset>
    </property>
    <property name="text">
-    <string>Run</string>
+    <string>&amp;Run</string>
    </property>
    <property name="toolTip">
     <string>Run or restart the simulation</string>
@@ -2721,7 +2870,7 @@
      <normaloff>:/icons/reduce.png</normaloff>:/icons/reduce.png</iconset>
    </property>
    <property name="text">
-    <string>Reduce</string>
+    <string>R&amp;educe</string>
    </property>
    <property name="toolTip">
     <string>Reduce the cut surface triangle count for more compact export.</string>
@@ -2748,7 +2897,7 @@
      <normaloff>:/icons/surface.png</normaloff>:/icons/surface.png</iconset>
    </property>
    <property name="text">
-    <string>Show Workpiece</string>
+    <string>Show Workpi&amp;ece</string>
    </property>
    <property name="toolTip">
     <string>Show uncut workpiece</string>
@@ -2798,7 +2947,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Fullscreen</string>
+    <string>F&amp;ullscreen</string>
    </property>
    <property name="shortcut">
     <string>F11</string>
@@ -2867,7 +3016,7 @@
      <normaloff>:/icons/undo.png</normaloff>:/icons/undo.png</iconset>
    </property>
    <property name="text">
-    <string>Undo</string>
+    <string>&amp;Undo</string>
    </property>
    <property name="toolTip">
     <string>Undo most recent edit.</string>
@@ -2882,7 +3031,7 @@
      <normaloff>:/icons/redo.png</normaloff>:/icons/redo.png</iconset>
    </property>
    <property name="text">
-    <string>Redo</string>
+    <string>&amp;Redo</string>
    </property>
    <property name="toolTip">
     <string>Redo recent edit.</string>
@@ -2897,7 +3046,7 @@
      <normaloff>:/icons/cut.png</normaloff>:/icons/cut.png</iconset>
    </property>
    <property name="text">
-    <string>Cut</string>
+    <string>&amp;Cut</string>
    </property>
    <property name="toolTip">
     <string>Cut selected text to clipboard.</string>
@@ -2912,7 +3061,7 @@
      <normaloff>:/icons/copy.png</normaloff>:/icons/copy.png</iconset>
    </property>
    <property name="text">
-    <string>Copy</string>
+    <string>C&amp;opy</string>
    </property>
    <property name="toolTip">
     <string>Copy selected text to clipboard.</string>
@@ -2927,7 +3076,7 @@
      <normaloff>:/icons/paste.png</normaloff>:/icons/paste.png</iconset>
    </property>
    <property name="text">
-    <string>Paste</string>
+    <string>&amp;Paste</string>
    </property>
    <property name="toolTip">
     <string>Paste clipboard contents to editor.</string>
@@ -2987,7 +3136,7 @@
      <normaloff>:/icons/optimize.png</normaloff>:/icons/optimize.png</iconset>
    </property>
    <property name="text">
-    <string>Optimize</string>
+    <string>&amp;Optimize</string>
    </property>
    <property name="toolTip">
     <string>Optimize rapid moves</string>
@@ -3120,7 +3269,7 @@
   </action>
   <action name="actionZoomOut">
    <property name="text">
-    <string>Zoom +</string>
+    <string>&amp;Zoom +</string>
    </property>
    <property name="toolTip">
     <string>Zoom Larger</string>
@@ -3163,6 +3312,17 @@
     <string>Show tool path intensity.  Useful for LASER paths that vary the S parameter.</string>
    </property>
   </action>
+  <action name="actionToggleText">
+   <property name="text">
+    <string>To&amp;ggle Text Editor</string>
+   </property>
+   <property name="iconText">
+    <string>Toggle Te&amp;xt Editor</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+X</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -3173,7 +3333,7 @@
   <customwidget>
    <class>CAMotics::FileTabManager</class>
    <extends>QTabWidget</extends>
-   <header>camotics/qt/FileTabManager.h</header>
+   <header location="global">camotics/qt/FileTabManager.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/qt/settings_dialog.ui
+++ b/qt/settings_dialog.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="generalTab">
       <attribute name="title">
@@ -195,6 +195,19 @@
              </widget>
             </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="separateFilesCheckBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Simulate each file separately</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/qt/tool_dialog.ui
+++ b/qt/tool_dialog.ui
@@ -62,7 +62,7 @@
             <number>0</number>
            </property>
            <property name="maximum">
-            <number>999</number>
+            <number>9999</number>
            </property>
           </widget>
          </item>
@@ -144,7 +144,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Angle</string>
+            <string>A&amp;ngle</string>
            </property>
            <property name="buddy">
             <cstring>lengthDoubleSpinBox</cstring>
@@ -178,7 +178,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Length</string>
+            <string>&amp;Length</string>
            </property>
            <property name="buddy">
             <cstring>lengthDoubleSpinBox</cstring>
@@ -209,7 +209,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Diameter</string>
+            <string>D&amp;iameter</string>
            </property>
            <property name="buddy">
             <cstring>diameterDoubleSpinBox</cstring>
@@ -240,7 +240,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Snub Diameter</string>
+            <string>Sn&amp;ub Diameter</string>
            </property>
            <property name="buddy">
             <cstring>snubDiameterDoubleSpinBox</cstring>

--- a/src/camotics/project/Project.cpp
+++ b/src/camotics/project/Project.cpp
@@ -48,6 +48,13 @@ void Project::setFilename(const string &_filename) {
 }
 
 
+void Project::setComments(const string &_comments) {
+  if (_comments.empty()) return;
+  comments = _comments;
+  markDirty();
+}
+
+
 string Project::getDirectory() const {
   return filename.empty() ? SystemUtilities::getcwd() :
     SystemUtilities::dirname(filename);
@@ -170,6 +177,7 @@ void Project::save(const string &_filename) {
 
 
 void Project::read(const JSON::Value &value) {
+  if (value.has("comments")) comments = value.getString("comments");
   units = GCode::Units::parse(value.getString("units", "metric"));
 
   resolutionMode =
@@ -185,6 +193,7 @@ void Project::read(const JSON::Value &value) {
 void Project::write(JSON::Sink &sink) const {
   sink.beginDict();
 
+  sink.insert("comments", comments);
   sink.insert("units", String::toLower(units.toString()));
   sink.insert("resolution-mode", String::toLower(resolutionMode.toString()));
   sink.insert("resolution", resolution);

--- a/src/camotics/project/Project.h
+++ b/src/camotics/project/Project.h
@@ -46,6 +46,7 @@ namespace CAMotics {
       bool dirty;
 
       std::string filename;
+      std::string comments = "";
       bool onDisk;
 
       GCode::ToolTable tools;
@@ -67,6 +68,8 @@ namespace CAMotics {
 
       const std::string &getFilename() const {return filename;}
       void setFilename(const std::string &filename);
+      const std::string &getComments() const {return comments;}
+      void setComments(const std::string &comments);
       std::string getDirectory() const;
       std::string getUploadFilename() const;
 

--- a/src/camotics/qt/FileTabManager.cpp
+++ b/src/camotics/qt/FileTabManager.cpp
@@ -105,7 +105,7 @@ void FileTabManager::open(const SmartPointer<Project::File> &file,
     if (0 < col)
       c.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, col);
 
-    c.select(QTextCursor::LineUnderCursor);
+    //c.select(QTextCursor::LineUnderCursor);
 
     editor->setTextCursor(c);
   }
@@ -340,6 +340,26 @@ void FileTabManager::on_modificationChanged(NCEdit *editor, bool changed) {
     QTabWidget::setTabText(tab, title.left(title.size() - 2));
 
   win->updateActions();
+}
+
+
+void FileTabManager::on_editorClicked(NCEdit *editor) {
+  if (this->win->isSync()) {
+    Project::File &file = *editor->getFile();
+    QString filename = QString(file.getPath().c_str());
+
+    if (!filename.isEmpty() && !filename.toLower().endsWith(".tpl")) {
+      QTextCursor cursor = editor->textCursor();
+      int position = cursor.position();
+
+      QTextDocument &document = *editor->document();
+      QString text = document.toPlainText();
+
+      int line = text.left(position).count('\n') + 1;
+
+      emit editorClicked(filename, line);
+    }
+  }
 }
 
 

--- a/src/camotics/qt/FileTabManager.h
+++ b/src/camotics/qt/FileTabManager.h
@@ -68,9 +68,11 @@ namespace CAMotics {
     void find();
     void findNext();
     void findResult(bool);
+    void editorClicked(QString, int);
 
   public slots:
     void on_modificationChanged(NCEdit *editor, bool changed);
+    void on_editorClicked(NCEdit *editor);
 
   protected slots:
     void on_tabCloseRequested(int index);

--- a/src/camotics/qt/GLView.h
+++ b/src/camotics/qt/GLView.h
@@ -24,6 +24,7 @@
 #include <cbang/util/SmartFunctor.h>
 
 #include <QOpenGLWidget>
+#include <QOpenGLFramebufferObject>
 
 
 class QOpenGLDebugLogger;
@@ -39,6 +40,9 @@ namespace CAMotics {
 
     cb::SmartPointer<QOpenGLDebugLogger> logger;
     bool enabled;
+    bool doPicking = false;
+    int xPicking = 0;
+    int yPicking = 0;
 
   public:
     GLView(QWidget *parent = 0);

--- a/src/camotics/qt/NCEdit.cpp
+++ b/src/camotics/qt/NCEdit.cpp
@@ -191,6 +191,7 @@ void NCEdit::loadLightScheme() {
   setColor(ColorComponent::Identifier, QColor("#000020"));
   setColor(ColorComponent::Keyword, QColor("#000080"));
   setColor(ColorComponent::BuiltIn, QColor("#008080"));
+  setColor(ColorComponent::Cursor, QColor("#134782" ));
   setColor(ColorComponent::Marker, QColor("#ffff00"));
 }
 
@@ -205,7 +206,7 @@ void NCEdit::loadDarkScheme() {
   setColor(ColorComponent::Identifier, QColor("#d9d9d9"));
   setColor(ColorComponent::Keyword, QColor("#00ffff"));
   setColor(ColorComponent::BuiltIn, QColor("#98fb98"));
-  setColor(ColorComponent::Cursor, QColor("#222222"));
+  setColor(ColorComponent::Cursor, QColor("#134782" ));
   setColor(ColorComponent::Marker, QColor("#d9d9d9"));
   setColor(ColorComponent::BracketMatch, QColor("#cd0000"));
 }
@@ -580,6 +581,12 @@ void NCEdit::wheelEvent(QWheelEvent *e) {
   }
 
   QPlainTextEdit::wheelEvent(e);
+}
+
+
+void NCEdit::mousePressEvent(QMouseEvent *e) {
+  QPlainTextEdit::mousePressEvent(e);
+  parent->on_editorClicked(this);
 }
 
 

--- a/src/camotics/qt/NCEdit.h
+++ b/src/camotics/qt/NCEdit.h
@@ -151,6 +151,7 @@ namespace CAMotics {
     void keyReleaseEvent(QKeyEvent *e);
     void resizeEvent(QResizeEvent *e);
     void wheelEvent(QWheelEvent *e);
+    void mousePressEvent(QMouseEvent *e);
 
   protected slots:
     void updateCursor();

--- a/src/camotics/qt/QtWin.h
+++ b/src/camotics/qt/QtWin.h
@@ -130,6 +130,9 @@ namespace CAMotics {
     std::string defaultExample;
     bool sliderMoving     = false;
     bool positionChanged  = false;
+    bool syncEditor       = false;
+    unsigned programLine  = 0;
+    QString programPath   = "";
 
     cb::SmartPointer<cb::LineBufferStream<ConsoleWriter> > consoleStream;
 
@@ -220,6 +223,7 @@ namespace CAMotics {
     bool checkSave(bool canCancel = true);
     void activateFile(const std::string &filename, int line = -1, int col = -1);
 
+    void updateComment();
     void updateActions();
     void updateUnits();
     void updateToolTables();
@@ -244,9 +248,13 @@ namespace CAMotics {
 
     bool isActive() {return lastStatusActive;}
     void setStatusActive(bool active);
+    bool isSync() {return syncEditor;}
+    void setSync(bool sync) {syncEditor = sync;}
 
     void showConsole();
     void hideConsole();
+    void showText();
+    void hideText();
     void appendConsole(const std::string &line);
 
     // Value Observers
@@ -272,6 +280,7 @@ namespace CAMotics {
     void updateFeed(const std::string &name, double value);
     void updateSpeed(const std::string &name, double value);
     void updateDirection(const std::string &name, const char *value);
+    void updateProgramName(const std::string &name, const char *value);
     void updateProgramLine(const std::string &name, unsigned value);
 
   protected:
@@ -296,6 +305,7 @@ namespace CAMotics {
     void on_bbctrlDisconnected();
     void on_machineChanged(QString machine, QString path);
 
+    void on_editorClicked(QString filename, int line);
     void on_fileTabManager_currentChanged(int index);
     void on_positionSlider_valueChanged(int position);
     void on_positionSlider_sliderPressed();
@@ -318,6 +328,8 @@ namespace CAMotics {
     void on_zOffsetDoubleSpinBox_valueChanged(double value);
 
     void on_languageChanged(QAction *action);
+    void on_commentsChanged();
+    void on_syncChanged();
 
     void on_actionQuit_triggered();
     void on_actionNew_triggered();
@@ -386,6 +398,8 @@ namespace CAMotics {
     void on_actionHideConsole_triggered();
     void on_actionShowConsole_triggered();
     void on_actionToggleConsole_triggered();
+
+    void on_actionToggleText_triggered();
 
     void on_hideConsolePushButton_clicked();
     void on_clearConsolePushButton_clicked();

--- a/src/camotics/qt/SettingsDialog.cpp
+++ b/src/camotics/qt/SettingsDialog.cpp
@@ -63,6 +63,11 @@ string SettingsDialog::getMachinePath() const {
 }
 
 
+bool SettingsDialog::getSeparateFiles() const {
+  return settings.get("Settings/SeparateFiles", 0).toBool();
+}
+
+
 bool SettingsDialog::getPlannerEnabled() const {
   return settings.get("Settings/Planner", 0).toInt();
 }
@@ -140,6 +145,8 @@ void SettingsDialog::load(Project::Project &project, View &view) {
 
   ui.resolutionDoubleSpinBox->setValue(project.getResolution());
   ui.resolutionComboBox->setCurrentIndex(project.getResolutionMode());
+  ui.separateFilesCheckBox->
+    setChecked(settings.get("Settings/SeparateFiles", 0).toBool());
   ui.unitsComboBox->setCurrentIndex(project.getUnits());
 
   ui.defaultUnitsComboBox->
@@ -165,6 +172,8 @@ void SettingsDialog::save(Project::Project &project, View &view) {
 
   if (mode == ResolutionMode::RESOLUTION_MANUAL)
     project.setResolution(ui.resolutionDoubleSpinBox->value());
+
+  settings.set("Settings/SeparateFiles", ui.separateFilesCheckBox->isChecked());
 
   GCode::Units units =
     (GCode::Units::enum_t)ui.unitsComboBox->currentIndex();

--- a/src/camotics/qt/SettingsDialog.h
+++ b/src/camotics/qt/SettingsDialog.h
@@ -57,6 +57,8 @@ namespace CAMotics {
     std::string getMachinePath() const;
     std::string getMachinePath(const std::string &machine) const;
 
+    bool getSeparateFiles() const;
+
     bool getPlannerEnabled() const;
     void setPlannerEnabled(bool enabled);
 

--- a/src/camotics/sim/SimulationRun.h
+++ b/src/camotics/sim/SimulationRun.h
@@ -39,7 +39,8 @@ namespace CAMotics {
     cb::SmartPointer<ToolSweep> sweep;
     cb::SmartPointer<GridTree> tree;
 
-    double lastTime;
+    double lastTime = 0;
+    double lastStart = 0;
 
   public:
     SimulationRun(const Simulation &sim);

--- a/src/camotics/sim/ToolSweep.h
+++ b/src/camotics/sim/ToolSweep.h
@@ -41,8 +41,8 @@ namespace CAMotics {
     cb::SmartPointer<GCode::ToolPath> path;
     std::vector<cb::SmartPointer<Sweep> > sweeps;
 
-    double startTime;
-    double endTime;
+    double startTime = 0;
+    double endTime = 0;
 
     cb::SmartPointer<MoveLookup> change;
 

--- a/src/camotics/view/Color.cpp
+++ b/src/camotics/view/Color.cpp
@@ -28,3 +28,4 @@ const Color Color::BLUE(0, 0, 1);
 const Color Color::CYAN(0, 1, 1);
 const Color Color::YELLOW(1, 1, 0);
 const Color Color::PURPLE(1, 0, 1);
+const Color Color::WHITE(1, 1, 1);

--- a/src/camotics/view/Color.h
+++ b/src/camotics/view/Color.h
@@ -43,5 +43,6 @@ namespace CAMotics {
     static const Color CYAN;
     static const Color YELLOW;
     static const Color PURPLE;
+    static const Color WHITE;
  };
 }

--- a/src/camotics/view/GLComposite.cpp
+++ b/src/camotics/view/GLComposite.cpp
@@ -30,6 +30,8 @@ void GLComposite::glDraw(GLContext &gl) {
   for (unsigned i = 0; i < objects.size(); i++) {
     GLObject &o = *objects[i];
     if (!o.isVisible()) continue;
+    // If color picking, only draw pickable objects
+    if (gl.getPicking() && !o.isPickable()) continue;
 
     bool identity = o.getTransform().isIdentity();
 
@@ -37,6 +39,7 @@ void GLComposite::glDraw(GLContext &gl) {
 
     GLProgram &program = gl.getProgram();
 
+    program.set("doPicking", gl.getPicking());
     program.set("light.enabled", o.getLight());
     if (o.getColor() != Color()) gl.setColor(o.getColor());
 

--- a/src/camotics/view/GLContext.h
+++ b/src/camotics/view/GLContext.h
@@ -35,6 +35,8 @@ namespace CAMotics {
     GLScene *scene;
     std::vector<Transform> stack;
 
+    bool doPicking = false;
+
   public:
     GLContext(GLScene *scene = 0);
 
@@ -56,6 +58,9 @@ namespace CAMotics {
 
     void setColor(const Color &c);
     void setColor(float r, float g, float b, float a = 1);
+
+    void setPicking(bool doPicking) {this->doPicking = doPicking;}
+    bool getPicking() const {return this->doPicking;}
 
   protected:
     void updateMatrix();

--- a/src/camotics/view/GLEnum.h
+++ b/src/camotics/view/GLEnum.h
@@ -25,5 +25,6 @@ namespace CAMotics {
     GL_ATTR_POSITION,
     GL_ATTR_NORMAL,
     GL_ATTR_COLOR,
+    GL_ATTR_PICKING,
   };
 }

--- a/src/camotics/view/GLObject.h
+++ b/src/camotics/view/GLObject.h
@@ -31,6 +31,7 @@ namespace CAMotics {
     Color color;
     bool light = true;
     bool visible = true;
+    bool pickable = false;
 
   public:
     virtual ~GLObject() {}
@@ -49,6 +50,9 @@ namespace CAMotics {
 
     void setVisible(bool visible) {this->visible = visible;}
     bool isVisible() const {return visible;}
+
+    void setPickable(bool pickable) {this->pickable = pickable;}
+    bool isPickable() const {return pickable;}
 
     virtual void glDraw(GLContext &gl) = 0;
   };

--- a/src/camotics/view/GLScene.h
+++ b/src/camotics/view/GLScene.h
@@ -73,7 +73,7 @@ namespace CAMotics {
 
     virtual void glResize(unsigned width, unsigned height);
     virtual void glInit();
-    virtual void glDraw();
+    virtual void glDraw(bool picking = false);
     using GLComposite::glDraw;
   };
 }

--- a/src/camotics/view/ToolPathView.h
+++ b/src/camotics/view/ToolPathView.h
@@ -36,27 +36,36 @@
 namespace CAMotics {
   class ToolPathView : public GLObject {
     ValueGroup values;
-    cb::SmartPointer<const GCode::ToolPath> path;
+    cb::SmartPointer<GCode::ToolPath> path;
 
     bool byRemote = true;
+    bool byLine = false;
+    bool separateFiles = false;
     double ratio = 1;
     cb::Vector3D position;
     unsigned line = 0;
+    std::string filename = "";
 
     double currentTime = 0;
     double currentDistance = 0;
     cb::Vector3D currentPosition;
+    std::string currentFilename = "";
     unsigned currentLine = 0;
     GCode::Move currentMove;
+
+    std::string selectedFilename = "";
+    unsigned selectedLine = 0;
 
     bool dirty = true;
     bool showIntensity = false;
 
     std::vector<float> vertices;
     std::vector<float> colors;
+    std::vector<float> picking;
 
-    VBO colorVBuf;
     VBO vertexVBuf;
+    VBO colorVBuf;
+    VBO pickingVBuf;
     unsigned numVertices = 0;
     unsigned numColors = 0;
 
@@ -66,12 +75,13 @@ namespace CAMotics {
     bool isEmpty() const {return path.isNull() || path->empty();}
 
     cb::SmartPointer<const GCode::ToolPath> getPath() const {return path;}
-    void setPath(const cb::SmartPointer<const GCode::ToolPath> &path);
+    void setPath(const cb::SmartPointer<GCode::ToolPath> &path);
 
     cb::Rectangle3D getBounds() const
     {return path.isNull() ? cb::Rectangle3D() : path->getBounds();}
 
     void setByRatio(double ratio);
+    void setByLine(std::string filename, unsigned line);
     void setByRemote(const cb::Vector3D &position, unsigned line);
 
     void incTime(double amount = 1);
@@ -94,10 +104,16 @@ namespace CAMotics {
     {return currentDistance / getTotalDistance() * 100;}
 
     const cb::Vector3D &getPosition() const {return currentPosition;}
+    const char *getFilename() const {return currentFilename.c_str();}
     unsigned getProgramLine() const {return currentLine;}
     const GCode::Move &getMove() const {return currentMove;}
 
+    const char *getSelectedFilename() const {return selectedFilename.c_str();}
+    unsigned getSelectedLine() const {return selectedLine;}
+
     void setShowIntensity(bool show);
+    void setSeparateFiles(bool value) {separateFiles = value;}
+    bool getSeparateFiles() const {return separateFiles;}
 
     unsigned getTool() const {return getMove().getTool();}
     double getFeed() const {return getMove().getFeed();}

--- a/src/camotics/view/View.cpp
+++ b/src/camotics/view/View.cpp
@@ -310,6 +310,7 @@ void View::glInit() {
   group->add(wireModel = new Lines(0, false, false));
   group->add(workpiece = new CuboidView);
   group->add(tool = new ToolView); // Last for transparency
+  group->setPickable(true);
 
   // Colors
   Color modelColor(0.06, 0.23, 0.42);
@@ -320,7 +321,7 @@ void View::glInit() {
 }
 
 
-void View::glDraw() {
+void View::glDraw(bool picking) {
   updateVisibility();
   updateBounds();
   path->update();
@@ -329,5 +330,5 @@ void View::glDraw() {
   updateMachine();
   updateAABB();
 
-  GLScene::glDraw();
+  GLScene::glDraw(picking);
 }

--- a/src/camotics/view/View.h
+++ b/src/camotics/view/View.h
@@ -128,6 +128,6 @@ namespace CAMotics {
 
     // From GLScene
     void glInit();
-    void glDraw();
+    void glDraw(bool picking = false);
   };
 }

--- a/src/gcode/Move.cpp
+++ b/src/gcode/Move.cpp
@@ -29,10 +29,13 @@ using namespace std;
 
 
 Move::Move(MoveType type, const Axes &start, const Axes &end, double startTime,
-           int tool, double feed, double speed, unsigned line, double time) :
+           int tool, double feed, double speed, unsigned line, double time,
+           const std::string &filename) :
   Segment3D(start.getXYZ(), end.getXYZ()), type(type), start(start), end(end),
   startTime(startTime), tool(tool), feed(feed), speed(speed), line(line),
   time(time), dist(start.distance(end))  {
+
+  this->filename = filename;
 
   // Estimate time in seconds from feed and distance
   if (!time) this->time = feed ? dist / feed * 60 : 0;

--- a/src/gcode/Move.h
+++ b/src/gcode/Move.h
@@ -44,17 +44,20 @@ namespace GCode {
     unsigned line = 0;
     double time = 0;
     double dist = 0;
+    std::string filename = "";
 
   public:
     Move() {}
     Move(MoveType type, const Axes &start, const Axes &end, double startTime,
-         int tool, double feed, double speed, unsigned line, double time);
+         int tool, double feed, double speed, unsigned line, double time,
+         const std::string &filename);
 
     MoveType getType() const {return type;}
     const Axes &getStart() const {return start;}
     const Axes &getEnd() const {return end;}
     const cb::Vector3D &getStartPt() const {return cb::Segment3D::getStart();}
     const cb::Vector3D &getEndPt() const {return cb::Segment3D::getEnd();}
+    const std::string &getFilename() const {return filename;}
     int getTool() const {return tool;}
     double getFeed() const {return feed;}
     double getSpeed() const {return speed;}

--- a/src/gcode/ToolPath.h
+++ b/src/gcode/ToolPath.h
@@ -41,6 +41,8 @@ namespace GCode {
     GCode::ToolTable tools;
 
     double time = 0;
+    double startTime = 0;
+    double endTime = 0;
     double distance = 0;
 
   public:
@@ -51,7 +53,12 @@ namespace GCode {
     const GCode::ToolTable &getTools() const {return tools;}
     GCode::ToolTable &getTools() {return tools;}
     double getTime() const {return time;}
+    double getStartTime() const {return startTime;}
+    double getEndTime() const {return endTime;}
     double getDistance() const {return distance;}
+
+    void setStartTime(double start) {startTime = start;}
+    void setEndTime(double end) {endTime = end;}
 
     int find(double time, unsigned first, unsigned last) const;
     int find(double time) const;

--- a/src/gcode/machine/MoveSink.cpp
+++ b/src/gcode/machine/MoveSink.cpp
@@ -53,7 +53,8 @@ void MoveSink::move(const Axes &position, int axes, bool rapid, double time) {
     double feed = rapid ? 10000 : getFeed(); // TODO Get rapid feed from machine
 
     Move move(type, start, end, this->time, get(TOOL_NUMBER, NO_UNITS),
-              feed, getSpeed(), getLocation().getStart().getLine(), time);
+              feed, getSpeed(), getLocation().getStart().getLine(), time,
+              getLocation().getStart().getFilename());
 
     this->time += move.getTime();
 

--- a/src/resources/shaders/phong.frag
+++ b/src/resources/shaders/phong.frag
@@ -5,6 +5,9 @@ precision mediump float;
 varying vec3 fNormal;
 varying vec3 fPosition;
 varying vec4 fColor;
+varying vec4 fPicking;
+
+uniform bool doPicking;
 
 struct Light {
   bool enabled;
@@ -30,6 +33,13 @@ vec4 phong_color() {
 
 
 void main() {
-  if (light.enabled) gl_FragColor = phong_color();
-  else gl_FragColor = fColor;
+  if (light.enabled) {
+    gl_FragColor = phong_color();
+  } else {
+    if (doPicking) {
+      gl_FragColor = fPicking;
+    } else {
+      gl_FragColor = fColor;
+    }
+  }
 }

--- a/src/resources/shaders/phong.vert
+++ b/src/resources/shaders/phong.vert
@@ -1,6 +1,7 @@
 attribute vec3 position;
 attribute vec3 normal;
 attribute vec4 color;
+attribute vec4 picking;
 
 uniform mat4 projection;
 uniform mat4 view;
@@ -10,11 +11,13 @@ uniform mat3 normalMat; // mat3(transpose(inverse(model)))
 varying vec3 fNormal;
 varying vec3 fPosition;
 varying vec4 fColor;
+varying vec4 fPicking;
 
 
 void main() {
   fPosition   = vec3(model * vec4(position, 1.0));
   fNormal     = normalMat * normal;
   fColor      = color;
+  fPicking    = picking;
   gl_Position = projection * view * vec4(fPosition, 1.0);
 }


### PR DESCRIPTION
This pull request is to add a number of features related to syncing the code to the simulation view. It encompasses a number requests such as #82, #208, #239, #259, #291, #293 and #295. In order to achieve this I had to make a number of changes to the GUI layout, the most dramatic being the placing of the GL View and Tab Manager side by side so they are visible at once. I was careful however to use a Splitter so the layout has the same flexibility as the console and other elements of the existing GUI.

The layout changes are:
- Moved the GL View from the first file tab into a separate left hand window.
- Moved the Tab Manager to the right of the GL View in a Splitter.
- Made the first permanent file tab a project comment text that is saved with the project files.
- Changed the Tab Manger to a vertical layout so filenames are still visible.
- Added a "Sync Text Editor to Simulation" toggle to the bottom of the Tab Manager to disable syncing (state is saved).
- Added "Program Name" to the Machine Status dock to show currently running program name.
- Changed the color of the text editor cursor to be more visible while moving (for both dark and light themes).
- Added "Toggle Text Editor" to the View menu to quickly open and close the text editor.
- Added the Tab Manager's Splitter position to work with the Default, Full and Minimal layouts.
- Added "Simulate each file separately" to the Settings dialog to change how multiple programs are simulated.
- Increased the range of the tool "Number" for the Tool Editor dialog to 9999 (for machines requiring larger tool IDs).
- Increased the number of steps to the simulation slider to make it more granular for complex programs.

The following program logic was added:
- If the Tab Manger is hidden it will automatically open when a file is opened.
- If the simulation is running and Sync is toggled in the Tab Manager, the current file and line is selected.
- If the simulation slider is changed and Sync is toggled in the Tab Manger, the current file and line is selected.
- If a line is selected in a file and Sync is toggled, the simulation will jump to that position.
- If a tool path line is right clicked in the GL View and Sync is toggled, that file and line will be selected.
- If multiple tool path lines overlap, the picker will toggle through them all.
- If the "Simulate each file separately" setting option is enabled each file is drawn separately in the GL View.
- When running a simulation or moving the slider, tool paths are drawn up to the current line however...
- When clicking in a file or GL View, the currently active tool path is white and all following paths are drawn dimly.

Most of the code modifications are in the ToolPathView and how it assembles tool paths and in GLView and how it does object picking. The GL View object picking is a simple "Color Picking" method involving coloring each tool path with the color of their file line position, and rendering this separately to a unsampled framebuffer.

The only concerns I have is I was not able to get TPL working in my Linux build so I have not tested it. The behavior of the code is to ignore TPL code as it cannot track the line position with the simulation, but it has not been tested. Also I had to scale the QOpenGLWidget size to fit the grabFramebuffer size as they do not match. The method is simple and from what I can tell the nested widgets created in QT's design editor can cause widgets to not report the proper size. Lastly I have not tried building this in Windows so I don't know if there are potential problems with the color picking as I can imagine that different operating systems and video hardware may mangle the color values or the frambuffer?


Here are some screenshots of the various changes...

Separate each file in settings...
![Settings](https://github.com/CauldronDevelopmentLLC/CAMotics/assets/11495643/7ac3af26-8382-480c-864a-f76b28e84ee7)

Full layout running simulation (tool path stop at current line)...
![FullLayout-Simulation](https://github.com/CauldronDevelopmentLLC/CAMotics/assets/11495643/fb779226-81ba-469e-a6ea-f192e766e63a)

Full layout during tool path picking (current tool path white with following paths dimmed)...
![FullLayout-PathPicking](https://github.com/CauldronDevelopmentLLC/CAMotics/assets/11495643/a3ce06a5-151c-48ea-ad72-a857a4498076)

Minimal layout with separate files in large project...
![MinimalLayout-SeparateFiles](https://github.com/CauldronDevelopmentLLC/CAMotics/assets/11495643/c38bb483-8c86-4ac0-bc58-9eb10623b7f6)

Minimal layout with all files rendered in large project...
![MinimalLayout-AllFiles](https://github.com/CauldronDevelopmentLLC/CAMotics/assets/11495643/a4812e05-3f74-48b2-bbd4-41ae96189a5f)

Cheers!