### PR TITLE
Add spiral picking, move dock and a few small features and bug fixes

### DIFF
--- a/qt/camotics.ui
+++ b/qt/camotics.ui
@@ -7,8 +7,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1437</width>
-    <height>869</height>
+    <width>1540</width>
+    <height>931</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -196,7 +196,7 @@
             <enum>QTabWidget::Triangular</enum>
            </property>
            <property name="currentIndex">
-            <number>0</number>
+            <number>-1</number>
            </property>
            <property name="elideMode">
             <enum>Qt::ElideNone</enum>
@@ -354,7 +354,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1437</width>
+     <width>1540</width>
      <height>23</height>
     </rect>
    </property>
@@ -611,7 +611,7 @@
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
-    <string>Tool Position</string>
+    <string>Tool Positio&amp;n</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -1071,7 +1071,7 @@
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
-    <string>Machine Status</string>
+    <string>&amp;Machine Status</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -1377,7 +1377,7 @@
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
-    <string>Tool Path Bounds</string>
+    <string>Tool Path Bo&amp;unds</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -1615,7 +1615,7 @@
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
-    <string>Workpiece Bounds</string>
+    <string>Wor&amp;kpiece Bounds</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -1672,6 +1672,9 @@
              <font>
               <underline>true</underline>
              </font>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
             </property>
             <property name="text">
              <string>Min</string>
@@ -2331,6 +2334,283 @@
         </size>
        </property>
       </spacer>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="moveInformationDockWidget">
+   <property name="minimumSize">
+    <size>
+     <width>259</width>
+     <height>135</height>
+    </size>
+   </property>
+   <property name="maximumSize">
+    <size>
+     <width>300</width>
+     <height>135</height>
+    </size>
+   </property>
+   <property name="features">
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <property name="windowTitle">
+    <string>Current Move</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>2</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_7">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_9" stretch="0">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>2</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QFrame" name="frame_4">
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_6">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <layout class="QGridLayout" name="gridLayout_10" columnstretch="0,1,1,1">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_29">
+            <property name="font">
+             <font>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="text">
+             <string>Y</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_35">
+            <property name="font">
+             <font>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string>Start</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_26">
+            <property name="font">
+             <font>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="text">
+             <string>X</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_36">
+            <property name="font">
+             <font>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="text">
+             <string>End</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_37">
+            <property name="font">
+             <font>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="text">
+             <string>Z</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="xStartMoveLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="xEndMoveLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="yStartMoveLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QLabel" name="yEndMoveLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLabel" name="zStartMoveLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="zEndMoveLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="label_38">
+            <property name="font">
+             <font>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="text">
+             <string>Distance</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QLabel" name="xMoveDistanceLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QLabel" name="yMoveDistanceLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QLabel" name="zMoveDistanceLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_39">
+            <property name="font">
+             <font>
+              <pointsize>12</pointsize>
+              <underline>true</underline>
+             </font>
+            </property>
+            <property name="text">
+             <string>Total Distance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="moveTotalDistanceLabel">
+            <property name="text">
+             <string>0.0</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
      </item>
     </layout>
    </widget>

--- a/src/camotics/qt/FileTabManager.cpp
+++ b/src/camotics/qt/FileTabManager.cpp
@@ -295,6 +295,13 @@ void FileTabManager::close(unsigned tab, bool canSave, bool removeTab) {
 }
 
 
+void FileTabManager::close(const SmartPointer<Project::File> &file,
+                           bool canSave, bool removeTab) {
+  for (unsigned tab = 0; tab < (unsigned)QTabWidget::count(); tab++)
+    if (getFile(tab) == file) close(tab, canSave, removeTab);
+}
+
+
 void FileTabManager::closeAll(bool canSave, bool removeTab) {
   for (int tab = 0; tab < QTabWidget::count(); tab++)
     close(tab, canSave, removeTab);

--- a/src/camotics/qt/FileTabManager.h
+++ b/src/camotics/qt/FileTabManager.h
@@ -55,6 +55,8 @@ namespace CAMotics {
     void revert(unsigned tab);
     void revertAll();
     void close(unsigned tab, bool canSave = true, bool removeTab = true);
+    void close(const cb::SmartPointer<Project::File> &file,
+               bool canSave = true, bool removeTab = true);
     void closeAll(bool canSave = true, bool removeTab = true);
 
     void validateTabIndex(unsigned tab) const;

--- a/src/camotics/qt/GLView.cpp
+++ b/src/camotics/qt/GLView.cpp
@@ -46,6 +46,24 @@ GLView::GLView(QWidget *parent) : QOpenGLWidget(parent), enabled(true) {
 #endif // DEBUG
 
   setFormat(format);
+
+  // Build square spiral picking pattern, starting from center
+  pickingPattern.push_back(vector<int>{0, 0});
+
+  for (int radStep = 1; radStep <= pickingRadius; radStep++) {
+    for (int topX = -radStep; topX < radStep; topX++) {
+      pickingPattern.push_back(vector<int>{topX, radStep});
+    }
+    for (int rightY = radStep; rightY > -radStep; rightY--) {
+      pickingPattern.push_back(vector<int>{radStep, rightY});
+    }
+    for (int botX = radStep; botX > -radStep; botX--) {
+      pickingPattern.push_back(vector<int>{botX, -radStep});
+    }
+    for (int leftY = -radStep; leftY < radStep; leftY++) {
+      pickingPattern.push_back(vector<int>{-radStep, leftY});
+    }
+  }
 }
 
 
@@ -157,25 +175,29 @@ void GLView::paintGL() {
     yPicking *= image.height() / (float)height();
 
     // Search area around mouse for pickable objects
-    int selRad = 6;
-    int xMin = max(0, xPicking - selRad);
-    int xMax = min(image.width() - 1, xPicking + selRad);
-    int yMin = max(0, yPicking - selRad);
-    int yMax = min(image.height() - 1, yPicking + selRad);
+    int xMin = max(0, xPicking - pickingRadius);
+    int xMax = min(image.width() - 1, xPicking + pickingRadius);
+    int yMin = max(0, yPicking - pickingRadius);
+    int yMax = min(image.height() - 1, yPicking + pickingRadius);
     vector<unsigned> moveList;
 
-    for (int x = xMin; x <= xMax; x++)
-      for (int y = yMin; y <= yMax; y++) {
+    for (int i = 0; i < pickingPattern.size(); i++) {
+      int x = xPicking + pickingPattern[i][0];
+      int y = yPicking + pickingPattern[i][1];
+
+      if (x >= xMin && x <= xMax && y >= yMin && y <= yMax) {
         QColor c = image.pixelColor(x, y);
 
         if (c != QColor(0, 0, 0, 255)) {
           // Convert picked color back to tool path line number
           unsigned moveIndex = Color::toIndex(c.redF(), c.greenF(), c.blueF());
 
-          if (!std::count(moveList.begin(), moveList.end(), moveIndex))
+          if (!std::count(moveList.begin(), moveList.end(), moveIndex)) {
             moveList.push_back(moveIndex);
+          }
         }
       }
+    }
 
     if (!moveList.empty()) {
       auto nextMove = std::find(moveList.begin(), moveList.end(), selectedMove);

--- a/src/camotics/qt/GLView.h
+++ b/src/camotics/qt/GLView.h
@@ -26,6 +26,8 @@
 #include <QOpenGLWidget>
 #include <QOpenGLFramebufferObject>
 
+#include <vector>
+
 
 class QOpenGLDebugLogger;
 class QOpenGLDebugMessage;
@@ -40,10 +42,12 @@ namespace CAMotics {
 
     cb::SmartPointer<QOpenGLDebugLogger> logger;
     bool enabled;
-    bool doPicking   = false;
+    bool doPicking = false;
     int xPicking = 0;
     int yPicking = 0;
+    int pickingRadius = 8;
     unsigned selectedMove = 0;
+    std::vector<std::vector<int>> pickingPattern;
 
   public:
     GLView(QWidget *parent = 0);

--- a/src/camotics/qt/QtWin.cpp
+++ b/src/camotics/qt/QtWin.cpp
@@ -267,6 +267,17 @@ void QtWin::init() {
   valueSet["program_file"]->add(this, &QtWin::updateProgramFile);
   valueSet["program_line"]->add(this, &QtWin::updateProgramLine);
 
+  valueSet["move_start_x"]->add(this, &QtWin::updateMoveStartX);
+  valueSet["move_start_y"]->add(this, &QtWin::updateMoveStartY);
+  valueSet["move_start_z"]->add(this, &QtWin::updateMoveStartZ);
+  valueSet["move_end_x"]->add(this, &QtWin::updateMoveEndX);
+  valueSet["move_end_y"]->add(this, &QtWin::updateMoveEndY);
+  valueSet["move_end_z"]->add(this, &QtWin::updateMoveEndZ);
+  valueSet["move_distance_x"]->add(this, &QtWin::updateMoveDistanceX);
+  valueSet["move_distance_y"]->add(this, &QtWin::updateMoveDistanceY);
+  valueSet["move_distance_z"]->add(this, &QtWin::updateMoveDistanceZ);
+  valueSet["move_distance_total"]->add(this, &QtWin::updateMoveDistanceTotal);
+
   valueSet.updated();
 }
 
@@ -1255,6 +1266,16 @@ void QtWin::newFile(bool tpl) {
 
   project->addFile(filename.toStdString());
   updateFiles();
+
+  // Reset view
+  view->clear();
+  redraw();
+
+  // Free old sim
+  surface.release();
+  simRun.release();
+
+  reload();
 }
 
 
@@ -1287,8 +1308,22 @@ void QtWin::editFile(unsigned index) {
 
 
 void QtWin::removeFile(unsigned index) {
+  // Remove text from editor
+  ui->fileTabManager->close(project->getFile(index), false, false);
+
+  // Remove file from project
   project->removeFile(index);
   updateFiles();
+
+  // Reset view
+  view->clear();
+  redraw();
+
+  // Free old sim
+  surface.release();
+  simRun.release();
+
+  reload();
 }
 
 
@@ -1779,7 +1814,7 @@ void QtWin::updateProgramLine(const string &name, unsigned value) {
   programLine = value;
 
   // Open and/or select file tab and highlight current line
-  if (0 < ui->splitterFile->sizes()[1] && programFile)
+  if (0 < ui->splitterFile->sizes()[1] && !programFile.empty())
     activateFile(programFile, value);
 
   ui->programLineLabel->setText(QString().sprintf("%d", value));
@@ -1794,6 +1829,75 @@ void QtWin::updateProgramFile(const string &name, const char *value) {
     setText(QString::fromStdString(SystemUtilities::basename(value)));
 }
 
+void QtWin::updateMoveStartX(const string &name, double value) {
+  double scale = isMetric() ? 1.0 : 1.0 / 25.4;
+  const char *prec = isMetric() ? "%.2f" : "%.3f";
+
+  ui->xStartMoveLabel->setText(QString().sprintf(prec, value * scale));
+}
+
+void QtWin::updateMoveStartY(const string &name, double value) {
+  double scale = isMetric() ? 1.0 : 1.0 / 25.4;
+  const char *prec = isMetric() ? "%.2f" : "%.3f";
+
+  ui->yStartMoveLabel->setText(QString().sprintf(prec, value * scale));
+}
+
+void QtWin::updateMoveStartZ(const string &name, double value) {
+  double scale = isMetric() ? 1.0 : 1.0 / 25.4;
+  const char *prec = isMetric() ? "%.2f" : "%.3f";
+
+  ui->zStartMoveLabel->setText(QString().sprintf(prec, value * scale));
+}
+
+void QtWin::updateMoveEndX(const string &name, double value) {
+  double scale = isMetric() ? 1.0 : 1.0 / 25.4;
+  const char *prec = isMetric() ? "%.2f" : "%.3f";
+
+  ui->xEndMoveLabel->setText(QString().sprintf(prec, value * scale));
+}
+
+void QtWin::updateMoveEndY(const string &name, double value) {
+  double scale = isMetric() ? 1.0 : 1.0 / 25.4;
+  const char *prec = isMetric() ? "%.2f" : "%.3f";
+
+  ui->yEndMoveLabel->setText(QString().sprintf(prec, value * scale));
+}
+
+void QtWin::updateMoveEndZ(const string &name, double value) {
+  double scale = isMetric() ? 1.0 : 1.0 / 25.4;
+  const char *prec = isMetric() ? "%.2f" : "%.3f";
+
+  ui->zEndMoveLabel->setText(QString().sprintf(prec, value * scale));
+}
+
+void QtWin::updateMoveDistanceX(const string &name, double value) {
+  double scale = isMetric() ? 1.0 : 1.0 / 25.4;
+  const char *prec = isMetric() ? "%.2f" : "%.3f";
+
+  ui->xMoveDistanceLabel->setText(QString().sprintf(prec, value * scale));
+}
+
+void QtWin::updateMoveDistanceY(const string &name, double value) {
+  double scale = isMetric() ? 1.0 : 1.0 / 25.4;
+  const char *prec = isMetric() ? "%.2f" : "%.3f";
+
+  ui->yMoveDistanceLabel->setText(QString().sprintf(prec, value * scale));
+}
+
+void QtWin::updateMoveDistanceZ(const string &name, double value) {
+  double scale = isMetric() ? 1.0 : 1.0 / 25.4;
+  const char *prec = isMetric() ? "%.2f" : "%.3f";
+
+  ui->zMoveDistanceLabel->setText(QString().sprintf(prec, value * scale));
+}
+
+void QtWin::updateMoveDistanceTotal(const string &name, double value) {
+  double scale = isMetric() ? 1.0 : 1.0 / 25.4;
+  const char *prec = isMetric() ? "%.2f" : "%.3f";
+
+  ui->moveTotalDistanceLabel->setText(QString().sprintf(prec, value * scale));
+}
 
 void QtWin::taskCompleted() {
   QCoreApplication::postEvent

--- a/src/camotics/qt/QtWin.h
+++ b/src/camotics/qt/QtWin.h
@@ -131,7 +131,7 @@ namespace CAMotics {
     bool sliderMoving       = false;
     bool positionChanged    = false;
     unsigned programLine    = 0;
-    const char *programFile = 0;
+    std::string programFile;
 
     cb::SmartPointer<cb::LineBufferStream<ConsoleWriter> > consoleStream;
 
@@ -278,6 +278,17 @@ namespace CAMotics {
     void updateDirection(const std::string &name, const char *value);
     void updateProgramLine(const std::string &name, unsigned value);
     void updateProgramFile(const std::string &name, const char *value);
+
+    void updateMoveStartX(const std::string &name, double value);
+    void updateMoveStartY(const std::string &name, double value);
+    void updateMoveStartZ(const std::string &name, double value);
+    void updateMoveEndX(const std::string &name, double value);
+    void updateMoveEndY(const std::string &name, double value);
+    void updateMoveEndZ(const std::string &name, double value);
+    void updateMoveDistanceX(const std::string &name, double value);
+    void updateMoveDistanceY(const std::string &name, double value);
+    void updateMoveDistanceZ(const std::string &name, double value);
+    void updateMoveDistanceTotal(const std::string &name, double value);
 
   protected:
     // From TaskObserver

--- a/src/camotics/view/ToolPathView.h
+++ b/src/camotics/view/ToolPathView.h
@@ -48,6 +48,17 @@ namespace CAMotics {
     double distance = 0;
     GCode::Move move;
 
+    double startX = 0;
+    double startY = 0;
+    double startZ = 0;
+    double endX = 0;
+    double endY = 0;
+    double endZ = 0;
+    double distanceX = 0;
+    double distanceY = 0;
+    double distanceZ = 0;
+    double totalDistance = 0;
+
     bool dirty = true;
     bool showIntensity = false;
 
@@ -107,6 +118,17 @@ namespace CAMotics {
     double   getFeed()  const {return getMove().getFeed();}
     double   getSpeed() const {return getMove().getSpeed();}
     const char *getDirection() const;
+
+    double getStartX() const {return startX;}
+    double getStartY() const {return startY;}
+    double getStartZ() const {return startZ;}
+    double getEndX() const {return endX;}
+    double getEndY() const {return endY;}
+    double getEndZ() const {return endZ;}
+    double getDistanceX() const {return distanceX;}
+    double getDistanceY() const {return distanceY;}
+    double getDistanceZ() const {return distanceZ;}
+    double getDistanceTotal() const {return totalDistance;}
 
     Color getColor(GCode::MoveType type, double intensity);
 


### PR DESCRIPTION
This pull request adds the following new features:
1) Square spiral picking pattern, starting from the selection center. This should make it more likely to select the path under cursor first.
2) New dock showing information for current move. This shows the move begin xyz coordinates, current xyz coordinates, and xyz distances and total distance (vector to vector distance). I find this useful to quickly determine part sizes when working with nested parts in sheets.

The following behaviors were changed:
1) Updates glview and simulation when adding files. I found it confusing having to manually reload after adding files.
2) Updates glview and simulation when removing files. Again I find this more intuitive then doing it manually.
3) Remove text tab when removing files. Not sure if this was overlooked but it seems strange to keep the text from a file that is removed?

The following bugs were fixed:
1) Fixed bug with move mid point time calculation for select by ratio. This was preventing simulation from showing partial moves, it would just jump to move end during simulation. I believe during the last refactor getPtAtTime(time) was not changed to getPtAtTime(targetTime).
2) Fixed bug with program name that was preventing it from updating between file changes. The problem was the pointer to the path strings were being compared, not the contents of the path strings.
3) Fixed bug causing glview to be black when in an empty project. This was caused by an error from indexing an empty path.

Here's a screenshot of the spiral search pattern, with the index drawn as color, in the framebuffer (just to visualize)...
![FrameBuffer](https://github.com/CauldronDevelopmentLLC/CAMotics/assets/11495643/b5ebc47d-0655-4553-9100-6629e3816d6a)

Here's a screenshot of the dock...
![CurrentMoveDock](https://github.com/CauldronDevelopmentLLC/CAMotics/assets/11495643/aeec3094-213c-4170-b27b-33672e19a0e1)

Cheers!