### PR TITLE
Treat single apostrophe as comment marker

### DIFF
--- a/src/gcode/parse/Tokenizer.cpp
+++ b/src/gcode/parse/Tokenizer.cpp
@@ -138,6 +138,7 @@ void Tokenizer::next() {
   case 0: current.set(EOF_TOKEN, ""); return;
 
   case '%': break; // Ignore program delimiter
+  case '\'': comment(); needAdvance = false; break;
   case ';': comment(); needAdvance = false; break;
   case '(': parenComment(); needAdvance = false; break;
 


### PR DESCRIPTION
I am using CAMotics to test out my programs made in Fusion 360 using NC postprocessor. The NC postprocessor uses single hyphen as a comment delimiter. Comments look like this:
```
G0 G17 G90
G0 G40 G49 G80
G21
'When using Fusion for Personal Use, the feedrate of rapid
'moves is reduced to match the feedrate of cutting moves,
'which can increase machining time. Unrestricted rapid moves
'are available with a Fusion Subscription.
G28 G91 Z0
G90
'Trace3
T2
```

So now I have to manually remove all the comments from the G-Code to be able to run it in CAMotics. Here is the fix for this.